### PR TITLE
linter-ignores-init: initial linter ignores

### DIFF
--- a/scripts/action-config.cfg
+++ b/scripts/action-config.cfg
@@ -1,5 +1,5 @@
 # We need to overload some default configuration,
-# when running inside Github Actions + ReviewDog.
+# when running inside GitHub Actions + ReviewDog.
 # Because we struggle to get the correct formatting.
 
 [flake8]
@@ -8,3 +8,11 @@
 format = default
 show-source = False
 statistics = False
+
+max-line-length = 100
+
+ignore = WPS112, WPS602, WPS305, WPS306, 
+
+per-file-ignores =
+  ./tests/**: DAR101, S101, D103
+  **/__init__.py: F401, WPS300

--- a/scripts/action-config.cfg
+++ b/scripts/action-config.cfg
@@ -9,9 +9,10 @@ format = default
 show-source = False
 statistics = False
 
-max-line-length = 100
+max-line-length = 88
+docstring-convention=numpy
 
-ignore = WPS112, WPS602, WPS305, WPS306, 
+ignore = WPS112, WPS602, WPS305, WPS306, E501
 
 per-file-ignores =
   ./tests/**: DAR101, S101, D103


### PR DESCRIPTION
Adds linter ignores listed in [aimb issue](https://github.com/AnyVisionltd/ai_module_builder/issues/201).